### PR TITLE
OSL-1463: improve pipeline-validator

### DIFF
--- a/cmd/config-validator/main.go
+++ b/cmd/config-validator/main.go
@@ -117,7 +117,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
+	if err = validateTag(ppDefConf, ppRepConf); err != nil {
+		log.Fatal(err)
+	}
 	err = ppDefConf.Merge(ppRepConf)
 	if err != nil {
 		log.Fatalf("Can't merge configs: %v", err)
@@ -130,4 +132,27 @@ func main() {
 	if !fail {
 		log.Fatal("Pipelines validation failed.")
 	}
+}
+
+func validateTag(ppDefConf, ppRepConf *pipelineconfig.Config) error {
+	getTag := func(config *pipelineconfig.Config) string {
+		const tag = "tag"
+		for _, param := range config.Defaults.Params {
+			if param.Name == tag {
+				return param.Param.Value.StringVal
+			}
+		}
+
+		return ""
+	}
+
+	ppDefTag := getTag(ppDefConf)
+	ppRepTag := getTag(ppRepConf)
+	if ppDefTag != "" && ppRepTag != "" {
+		if ppDefTag != ppRepTag {
+			return fmt.Errorf("mismatched default: %s and local: %s tags", ppDefTag, ppRepTag)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
TASK: https://app.clickup.com/t/8630481/OSL-1478  

**Suggestion:**
- Add 'tag' param value to match default and local params as defined at [example](https://github.com/ElementalCognition/protos/blob/main/.tekton.yaml#L52)  

**Assumption:**
- As defined in the task and the [issue](https://github.com/ElementalCognition/tekton-toolbox/issues/318), we have to compare the tag with 'main' branch.  
So we can use github api for ex to [fetch the latest tag](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags)
- Example flow: after all pipelines successfully passed, we are fetching the latest 'main' tag and proceed validation.